### PR TITLE
create directory before copying files into it

### DIFF
--- a/scripts/install-paclet.wls
+++ b/scripts/install-paclet.wls
@@ -38,7 +38,8 @@ Module[{
 	If[FileExistsQ[dest],
 		DeleteFile[dest];
 	];
-
+	
+	CreateDirectory[FileNameDrop[dest]];
 	CopyFile[source, dest]
 ]
 


### PR DESCRIPTION
this fixes an error when trying to build/install wolfram-cli on my machine