### PR TITLE
polish: Improve Failure formatting by working around Failure formatting bug

### DIFF
--- a/WolframCLI/Source/WolframCLI/TerminalForm.wl
+++ b/WolframCLI/Source/WolframCLI/TerminalForm.wl
@@ -20,14 +20,25 @@ Needs["GeneralUtilities`" -> None]
 
 Needs["MUnit`"]
 
-TerminalStyle[expr_] := ToString[expr, OutputForm]
+TerminalStyle[expr_] := Replace[expr, {
+	(* Workaround bug in ToString[_Failure, OutputForm] adding extra
+	   TagBox[PaneBox[..]]] wrapper. *)
+	Failure[tag_, KeyValuePattern[{
+		"MessageTemplate" -> template_String,
+		"MessageParameters" -> params_List
+	}]] :> (
+		TemplateApply[template, params, InsertionFunction -> ToString]
+	),
+
+	other_ :> ToString[expr, OutputForm]
+}]
 
 TerminalStyle[expr_, styles0__] := Module[{
 	styles = {styles0},
 	codes,
 	ansiStyle,
 	ansiReset = "\:001b[0m",
-	exprLines = StringSplit[ToString[expr, OutputForm], "\n"]
+	exprLines = StringSplit[TerminalStyle[expr], "\n"]
 },
 	codes = Map[ToString @* styleEscapeCode, styles];
 

--- a/WolframCLI/Source/WolframCLI/WolframCLI.wl
+++ b/WolframCLI/Source/WolframCLI/WolframCLI.wl
@@ -769,6 +769,11 @@ CommandPrintTerminalFormDebug[] := Module[{
 			|>]
 		|>]
 	|>]];
+
+	Print["Error with format argument: ", TerminalForm @ Failure["Level1", <|
+		"MessageTemplate" -> "The problem is in: ``",
+		"MessageParameters" -> {InputForm["Hello"]}
+	|>]];
 ]
 
 (*====================================*)

--- a/docs/Development.md
+++ b/docs/Development.md
@@ -23,7 +23,7 @@ $ wolfram-cli paclet test ./build/ConnorGray__WolframCLI ./Tests
 #### Debug TerminalForm output
 
 ```
-$ wolfram print-terminal-form-debug
+$ wolfram-cli print-terminal-form-debug
 ```
 
 #### Regenerate docs/CommandLineHelp.md


### PR DESCRIPTION
Before:

    The problem is in: TagBox[PaneBox["\"Hello\"", BaselinePosition -> Baseline], #1 & ]

After:

    The problem is in: "Hello"